### PR TITLE
Deploy nlpcaffe on Docker on Amazon Ubuntu 14.01 p2.xlarge from scratch

### DIFF
--- a/docker/standalone/gpu/Ubuntu14.04-AMI/Makefile.config
+++ b/docker/standalone/gpu/Ubuntu14.04-AMI/Makefile.config
@@ -1,0 +1,106 @@
+## Refer to http://caffe.berkeleyvision.org/installation.html
+# Contributions simplifying and improving our build system are welcome!
+
+# cuDNN acceleration switch (uncomment to build with cuDNN).
+USE_CUDNN := 1
+
+# CPU-only switch (uncomment to build without GPU support).
+# CPU_ONLY := 1
+
+# uncomment to disable IO dependencies and corresponding data layers
+# USE_OPENCV := 0
+# USE_LEVELDB := 0
+# USE_LMDB := 0
+
+# uncomment to allow MDB_NOLOCK when reading LMDB files (only if necessary)
+#	You should not set this flag if you will be reading LMDBs with any
+#	possibility of simultaneous read and write
+# ALLOW_LMDB_NOLOCK := 1
+
+# Uncomment if you're using OpenCV 3
+# OPENCV_VERSION := 3
+
+# To customize your choice of compiler, uncomment and set the following.
+# N.B. the default for Linux is g++ and the default for OSX is clang++
+# CUSTOM_CXX := g++
+
+# CUDA directory contains bin/ and lib/ directories that we need.
+CUDA_DIR := /usr/local/cuda
+# On Ubuntu 14.04, if cuda tools are installed via
+# "sudo apt-get install nvidia-cuda-toolkit" then use this instead:
+# CUDA_DIR := /usr
+
+# CUDA architecture setting: going with all of them.
+# For CUDA < 6.0, comment the *_50 lines for compatibility.
+CUDA_ARCH := -gencode arch=compute_20,code=sm_20 \
+	-gencode arch=compute_20,code=sm_21 \
+	-gencode arch=compute_30,code=sm_30 \
+	-gencode arch=compute_35,code=sm_35 \
+	-gencode arch=compute_50,code=sm_50 \
+	-gencode arch=compute_50,code=compute_50
+
+# BLAS choice:
+# atlas for ATLAS (default)
+# mkl for MKL
+# open for OpenBlas
+BLAS := atlas
+# Custom (MKL/ATLAS/OpenBLAS) include and lib directories.
+# Leave commented to accept the defaults for your choice of BLAS
+# (which should work)!
+# BLAS_INCLUDE := /path/to/your/blas
+# BLAS_LIB := /path/to/your/blas
+
+# Homebrew puts openblas in a directory that is not on the standard search path
+# BLAS_INCLUDE := $(shell brew --prefix openblas)/include
+# BLAS_LIB := $(shell brew --prefix openblas)/lib
+
+# This is required only if you will compile the matlab interface.
+# MATLAB directory should contain the mex binary in /bin.
+# MATLAB_DIR := /usr/local
+# MATLAB_DIR := /Applications/MATLAB_R2012b.app
+
+# NOTE: this is required only if you will compile the python interface.
+# We need to be able to find Python.h and numpy/arrayobject.h.
+# PYTHON_INCLUDE := /usr/include/python2.7 \
+	# /usr/lib/python2.7/dist-packages/numpy/core/include
+# Anaconda Python distribution is quite popular. Include path:
+# Verify anaconda location, sometimes it's in root.
+ANACONDA_HOME := /opt/conda
+PYTHON_INCLUDE := $(ANACONDA_HOME)/include \
+	$(ANACONDA_HOME)/include/python2.7 \
+	$(ANACONDA_HOME)/lib/python2.7/site-packages/numpy/core/include
+
+# We need to be able to find libpythonX.X.so or .dylib.
+# PYTHON_LIB := /usr/lib
+PYTHON_LIB := $(ANACONDA_HOME)/lib
+
+# Homebrew installs numpy in a non standard path (keg only)
+# PYTHON_INCLUDE += $(dir $(shell python -c 'import numpy.core; print(numpy.core.__file__)'))/include
+# PYTHON_LIB += $(shell brew --prefix numpy)/lib
+
+# Uncomment to support layers written in Python (will link against Python libs)
+# WITH_PYTHON_LAYER := 1
+
+# Whatever else you find you need goes here.
+INCLUDE_DIRS := $(PYTHON_INCLUDE) /usr/local/include
+LIBRARY_DIRS := $(PYTHON_LIB) /usr/local/lib /usr/lib
+
+# If Homebrew is installed at a non standard location (for example your home directory) and you use it for general dependencies
+# INCLUDE_DIRS += $(shell brew --prefix)/include
+# LIBRARY_DIRS += $(shell brew --prefix)/lib
+
+# Uncomment to use `pkg-config` to specify OpenCV library paths.
+# (Usually not necessary -- OpenCV libraries are normally installed in one of the above $LIBRARY_DIRS.)
+# USE_PKG_CONFIG := 1
+
+BUILD_DIR := build
+DISTRIBUTE_DIR := distribute
+
+# Uncomment for debugging. Does not work on OSX due to https://github.com/BVLC/caffe/issues/171
+# DEBUG := 1
+
+# The ID of the GPU that 'make runtest' will use to run unit tests.
+TEST_GPUID := 0
+
+# enable pretty build (comment to see full commands)
+Q ?= @

--- a/docker/standalone/gpu/Ubuntu14.04-AMI/step_0-configure_gpu.sh
+++ b/docker/standalone/gpu/Ubuntu14.04-AMI/step_0-configure_gpu.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+for TESTFOR in "NVIDIA-Linux-x86_64-367.57.run" "nvidia-docker_1.0.0.rc.3-1_amd64.deb" 
+do
+    if [ ! -e $TESTFOR ]
+    then
+        echo File '"'$TESTFOR'"' must be present in this directory
+        exit 5
+    fi
+done
+
+# Reference:
+#   https://github.com/NVIDIA/nvidia-docker/wiki/Deploy-on-Amazon-EC2
+
+# Install NVIDIA drivers 367.57
+#  This is incrementally newer than the version that we get updated to below (367.48) if we follow the instructions and install 361.42
+#  Hoping this works since 367.48 has been removed from the NVidia downloads site
+wget http://us.download.nvidia.com/XFree86/Linux-x86_64/367.57/NVIDIA-Linux-x86_64-367.57.run
+sudo apt-get -q install --no-install-recommends -y gcc make libc-dev
+sudo sh NVIDIA-Linux-x86_64-367.57.run --ui=none --no-questions --accept-license

--- a/docker/standalone/gpu/Ubuntu14.04-AMI/step_0-configure_gpu.sh
+++ b/docker/standalone/gpu/Ubuntu14.04-AMI/step_0-configure_gpu.sh
@@ -1,14 +1,5 @@
 #!/bin/bash
 
-for TESTFOR in "NVIDIA-Linux-x86_64-367.57.run" "nvidia-docker_1.0.0.rc.3-1_amd64.deb" 
-do
-    if [ ! -e $TESTFOR ]
-    then
-        echo File '"'$TESTFOR'"' must be present in this directory
-        exit 5
-    fi
-done
-
 # Reference:
 #   https://github.com/NVIDIA/nvidia-docker/wiki/Deploy-on-Amazon-EC2
 

--- a/docker/standalone/gpu/Ubuntu14.04-AMI/step_0-configure_gpu.sh
+++ b/docker/standalone/gpu/Ubuntu14.04-AMI/step_0-configure_gpu.sh
@@ -2,6 +2,7 @@
 
 # START WITH AMI (or regional equivalent):
 #  ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-20161213 (ami-5ac2cd4d)
+#  launch on p2.xlarge instance
 
 # Reference:
 #   https://github.com/NVIDIA/nvidia-docker/wiki/Deploy-on-Amazon-EC2

--- a/docker/standalone/gpu/Ubuntu14.04-AMI/step_0-configure_gpu.sh
+++ b/docker/standalone/gpu/Ubuntu14.04-AMI/step_0-configure_gpu.sh
@@ -6,6 +6,13 @@
 sudo apt-get -qq update -y
 sudo apt-get -q install --no-install-recommends -y gcc make libc-dev wget
 
+CURRRENT_VER_LINE=$(cat cat /proc/driver/nvidia/version | head -1 )
+if [[ $CURRRENT_VER_LINE == *"367.57"* ]]; then
+  echo "We have the correct version"
+  echo "Skip the reboot and continue to step 2"
+  exit
+fi
+
 # Install NVIDIA drivers 367.57
 #  This is incrementally newer than the version 367.48 that the Ubuntu repos hold.
 #  NVidia no longer has the 367.48 version on their downloads site and we have

--- a/docker/standalone/gpu/Ubuntu14.04-AMI/step_0-configure_gpu.sh
+++ b/docker/standalone/gpu/Ubuntu14.04-AMI/step_0-configure_gpu.sh
@@ -3,8 +3,9 @@
 # Reference:
 #   https://github.com/NVIDIA/nvidia-docker/wiki/Deploy-on-Amazon-EC2
 
-sudo apt-get -qq update -y
-sudo apt-get -q install --no-install-recommends -y gcc make libc-dev wget
+sudo apt-get -q update -y
+sudo apt-get -q install -y build-essential kernel-package linux-image-extra-`uname -r` linux-image-extra-virtual wget 
+sudo apt-get -q update -y
 
 CURRRENT_VER_LINE=$(cat cat /proc/driver/nvidia/version | head -1 )
 if [[ $CURRRENT_VER_LINE == *"367.57"* ]]; then

--- a/docker/standalone/gpu/Ubuntu14.04-AMI/step_0-configure_gpu.sh
+++ b/docker/standalone/gpu/Ubuntu14.04-AMI/step_0-configure_gpu.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# START WITH AMI (or regional equivalent):
+#  ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-20161213 (ami-5ac2cd4d)
+
 # Reference:
 #   https://github.com/NVIDIA/nvidia-docker/wiki/Deploy-on-Amazon-EC2
 

--- a/docker/standalone/gpu/Ubuntu14.04-AMI/step_0-configure_gpu.sh
+++ b/docker/standalone/gpu/Ubuntu14.04-AMI/step_0-configure_gpu.sh
@@ -12,9 +12,12 @@ done
 # Reference:
 #   https://github.com/NVIDIA/nvidia-docker/wiki/Deploy-on-Amazon-EC2
 
+sudo apt-get -qq update -y
+sudo apt-get -q install --no-install-recommends -y gcc make libc-dev wget
+
 # Install NVIDIA drivers 367.57
-#  This is incrementally newer than the version that we get updated to below (367.48) if we follow the instructions and install 361.42
-#  Hoping this works since 367.48 has been removed from the NVidia downloads site
+#  This is incrementally newer than the version 367.48 that the Ubuntu repos hold.
+#  NVidia no longer has the 367.48 version on their downloads site and we have
+#  to have the *.run file so that we match the host and the Docker container
 wget http://us.download.nvidia.com/XFree86/Linux-x86_64/367.57/NVIDIA-Linux-x86_64-367.57.run
-sudo apt-get -q install --no-install-recommends -y gcc make libc-dev
 sudo sh NVIDIA-Linux-x86_64-367.57.run --ui=none --no-questions --accept-license

--- a/docker/standalone/gpu/Ubuntu14.04-AMI/step_1-reboot.sh
+++ b/docker/standalone/gpu/Ubuntu14.04-AMI/step_1-reboot.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+shutdown -r now
+

--- a/docker/standalone/gpu/Ubuntu14.04-AMI/step_2-install-nvidia_docker.sh
+++ b/docker/standalone/gpu/Ubuntu14.04-AMI/step_2-install-nvidia_docker.sh
@@ -1,10 +1,15 @@
 #!/bin/bash
 
-sudo apt-get update
-sudo apt-get install curl \
-     libsystemd-journal0 \
+# Output from this command verifies we got our drivers set up
+nvidia-smi
+
+# This is mostly a repeat of installs that occurred in step 0 ... here for clarity of what Docker install requires
+sudo apt-get update -y
+sudo apt-get install -y curl \
+    build-essential \
+    libsystemd-journal0 \
     linux-image-extra-$(uname -r) \
-    linux-image-extra-virtual \
+    linux-image-extra-virtual
     
 
 sudo apt-get install apt-transport-https ca-certificates

--- a/docker/standalone/gpu/Ubuntu14.04-AMI/step_2-install-nvidia_docker.sh
+++ b/docker/standalone/gpu/Ubuntu14.04-AMI/step_2-install-nvidia_docker.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# Install nvidia-docker and nvidia-docker-plugin
+wget https://github.com/NVIDIA/nvidia-docker/releases/download/v1.0.0-rc.3/nvidia-docker_1.0.0.rc.3-1_amd64.deb
+sudo dpkg -i nvidia-docker_1.0.0.rc.3-1_amd64.deb

--- a/docker/standalone/gpu/Ubuntu14.04-AMI/step_2-install-nvidia_docker.sh
+++ b/docker/standalone/gpu/Ubuntu14.04-AMI/step_2-install-nvidia_docker.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Output from this command verifies we got our drivers set up
-nvidia-smi
+sudo nvidia-smi
 
 # This is mostly a repeat of installs that occurred in step 0 ... here for clarity of what Docker install requires
 sudo apt-get update -y
@@ -12,7 +12,7 @@ sudo apt-get install -y curl \
     linux-image-extra-virtual
     
 
-sudo apt-get install apt-transport-https ca-certificates
+sudo apt-get install -y apt-transport-https ca-certificates
 
 curl -fsSL https://yum.dockerproject.org/gpg | sudo apt-key add -
 

--- a/docker/standalone/gpu/Ubuntu14.04-AMI/step_2-install-nvidia_docker.sh
+++ b/docker/standalone/gpu/Ubuntu14.04-AMI/step_2-install-nvidia_docker.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
 
+sudo apt-get update
+sudo apt-get install curl \
+     libsystemd-journal0 \
+    linux-image-extra-$(uname -r) \
+    linux-image-extra-virtual \
+    
+
+sudo apt-get install apt-transport-https ca-certificates
+
+curl -fsSL https://yum.dockerproject.org/gpg | sudo apt-key add -
+
+wget https://apt.dockerproject.org/repo/pool/main/d/docker-engine/docker-engine_1.10.0-0~trusty_amd64.deb
+sudo dpkg -i docker-engine_1.10.0-0~trusty_amd64.deb
+
 # Install nvidia-docker and nvidia-docker-plugin
 wget https://github.com/NVIDIA/nvidia-docker/releases/download/v1.0.0-rc.3/nvidia-docker_1.0.0.rc.3-1_amd64.deb
 sudo dpkg -i nvidia-docker_1.0.0.rc.3-1_amd64.deb

--- a/docker/standalone/gpu/Ubuntu14.04-AMI/step_2-install-nvidia_docker.sh
+++ b/docker/standalone/gpu/Ubuntu14.04-AMI/step_2-install-nvidia_docker.sh
@@ -14,6 +14,11 @@ curl -fsSL https://yum.dockerproject.org/gpg | sudo apt-key add -
 wget https://apt.dockerproject.org/repo/pool/main/d/docker-engine/docker-engine_1.10.0-0~trusty_amd64.deb
 sudo dpkg -i docker-engine_1.10.0-0~trusty_amd64.deb
 
+sudo groupadd docker
+sudo gpasswd -a ${USER} docker
+sudo service docker restart
+
+
 # Install nvidia-docker and nvidia-docker-plugin
 wget https://github.com/NVIDIA/nvidia-docker/releases/download/v1.0.0-rc.3/nvidia-docker_1.0.0.rc.3-1_amd64.deb
 sudo dpkg -i nvidia-docker_1.0.0.rc.3-1_amd64.deb

--- a/docker/standalone/gpu/Ubuntu14.04-AMI/step_3-make_docker.sh
+++ b/docker/standalone/gpu/Ubuntu14.04-AMI/step_3-make_docker.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+docker build -f ubuntu-nvidia367.57-cuda7.5-cudnn4-gpu-nlpcaffe.docker -t ubuntu-nvidia367.57-cuda7.5-cudnn4-gpu-nlpcaffe:1 .
+

--- a/docker/standalone/gpu/Ubuntu14.04-AMI/step_3-make_docker.sh
+++ b/docker/standalone/gpu/Ubuntu14.04-AMI/step_3-make_docker.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
-docker build -f ubuntu-nvidia367.57-cuda7.5-cudnn4-gpu-nlpcaffe.docker -t ubuntu-nvidia367.57-cuda7.5-cudnn4-gpu-nlpcaffe:1 .
+
+# To avoid having to use sudo here one must re-login after the previous step
+sudo docker build -f ubuntu-nvidia367.57-cuda7.5-cudnn4-gpu-nlpcaffe.docker -t ubuntu-nvidia367.57-cuda7.5-cudnn4-gpu-nlpcaffe:1 .
 

--- a/docker/standalone/gpu/Ubuntu14.04-AMI/step_4-test_nlpcaffe.sh
+++ b/docker/standalone/gpu/Ubuntu14.04-AMI/step_4-test_nlpcaffe.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-docker run -it --device=/dev/nvidiactl --device=/dev/nvidia-uvm --device=/dev/nvidia0 ubuntu-nvidia367.57-cuda7.5-cudnn4-gpu-nlpcaffe:1  /bin/bash -c 'cd /home/caffe-user/nlpcaffe ; ./data/language_model/get_lm.sh; python ./examples/language_model/create_lm.py --make_data ; ./examples/language_model/train_lm.sh'
+sudo docker run -it --device=/dev/nvidiactl --device=/dev/nvidia-uvm --device=/dev/nvidia0 ubuntu-nvidia367.57-cuda7.5-cudnn4-gpu-nlpcaffe:1  /bin/bash -c 'cd /home/caffe-user/nlpcaffe ; ./data/language_model/get_lm.sh; python ./examples/language_model/create_lm.py --make_data ; ./examples/language_model/train_lm.sh'

--- a/docker/standalone/gpu/Ubuntu14.04-AMI/step_4-test_nlpcaffe.sh
+++ b/docker/standalone/gpu/Ubuntu14.04-AMI/step_4-test_nlpcaffe.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker run -it --device=/dev/nvidiactl --device=/dev/nvidia-uvm --device=/dev/nvidia0 ubuntu-nvidia367.57-cuda7.5-cudnn4-gpu-nlpcaffe:1  /bin/bash -c 'cd /home/caffe-user/nlpcaffe ; ./data/language_model/get_lm.sh; python ./examples/language_model/create_lm.py --make_data ; ./examples/language_model/train_lm.sh'

--- a/docker/standalone/gpu/Ubuntu14.04-AMI/ubuntu-nvidia367.57-cuda7.5-cudnn4-gpu-nlpcaffe.docker
+++ b/docker/standalone/gpu/Ubuntu14.04-AMI/ubuntu-nvidia367.57-cuda7.5-cudnn4-gpu-nlpcaffe.docker
@@ -1,0 +1,149 @@
+#MUST BE BUILT on a system having NVidia driver support:
+#
+#   See step_0-configure_gpu.sh for more details and:
+#   https://github.com/NVIDIA/nvidia-docker/wiki/Deploy-on-Amazon-EC2
+#   https://developer.nvidia.com/cuda-downloads
+#
+# NOTE: best documentation of how to put the parts together is in NVidia's
+#       CentOs DockerFiles.  The Ubuntu files don't have containers broken out
+#       by version of cuda and cudnn like the CentOs files do.
+#
+#     https://github.com/NVIDIA/nvidia-docker/blob/master/centos-7/cuda/7.5/devel/cudnn4/Dockerfile
+#     depends on:
+#     https://github.com/NVIDIA/nvidia-docker/blob/master/centos-7/cuda/7.5/devel/Dockerfile
+#     depends on:
+#     https://github.com/NVIDIA/nvidia-docker/blob/master/centos-7/cuda/7.5/runtime/Dockerfile
+#     depends on:
+#     centos:7
+#
+    
+FROM ubuntu:14.04
+
+USER root
+
+# Install git, bc and dependencies
+RUN apt-get -qq update -y
+RUN apt-get update --fix-missing && apt-get install -y \
+  curl \
+  wget \
+  bzip2 \
+  ca-certificates \
+  sudo \
+  git \
+  bc \
+  vim \
+  procps \
+  curl \
+  libglib2.0-0 \
+  libxext6 \
+  libsm6 \
+  libxrender1 \
+  libatlas-base-dev \
+  libatlas-dev \
+  libboost-all-dev \
+  libopencv-dev \
+  libprotobuf-dev \
+  libgoogle-glog-dev \
+  libgflags-dev \
+  protobuf-compiler \
+  libhdf5-dev \
+  libleveldb-dev \
+  liblmdb-dev \
+  libsnappy-dev \
+  htop
+
+# wget is in step_0 script ... no need to download twice and the OS driver and the Docker driver absolutely have to match
+COPY NVIDIA-Linux-x86_64-367.57.run .
+
+LABEL com.nvidia.volumes.needed="nvidia_driver"
+# The --no-kernel-module is the key for the Docker install
+RUN sh "NVIDIA-Linux-x86_64-367.57.run" --ui=none --no-questions --accept-license --no-kernel-module
+
+RUN NVIDIA_GPGKEY_SUM=d1be581509378368edeec8c1eb2958702feedf3bc3d17011adbf24efacce4ab5 && \
+    NVIDIA_GPGKEY_FPR=ae09fe4bbd223a84b2ccfce3f60f4b3d7fa2af80 && \
+    apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1404/x86_64/7fa2af80.pub && \
+    apt-key adv --export --no-emit-version -a $NVIDIA_GPGKEY_FPR | tail -n +2 > cudasign.pub && \
+    echo "$NVIDIA_GPGKEY_SUM  cudasign.pub" | sha256sum -c --strict - && rm cudasign.pub && \
+    echo "deb http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1404/x86_64 /" > /etc/apt/sources.list.d/cuda.list
+
+#  Goto http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1404/x86_64 in browser
+#  We want a 7.5 version and looks like we have one option:
+#      cuda-7-5_7.5-18_amd64.deb 
+#  Also reference:  https://github.com/NVIDIA/nvidia-docker/blob/master/centos-7/cuda/7.5/runtime/Dockerfile
+
+ENV CUDA_VERSION 7.5
+LABEL com.nvidia.cuda.version="7.5"
+
+RUN curl -fsSL http://developer.download.nvidia.com/compute/cuda/7.5/Prod/local_installers/cuda_7.5.18_linux.run -O
+RUN chmod +x cuda_7.5.18_linux.run
+RUN ./cuda_7.5.18_linux.run --extract=$HOME
+RUN $HOME/cuda-linux64-rel-7.5.18-19867135.run -noprompt
+RUN stat /usr/local/cuda/lib64
+
+RUN echo "/usr/local/cuda/lib" >> /etc/ld.so.conf.d/cuda.conf && \
+    echo "/usr/local/cuda/lib64" >> /etc/ld.so.conf.d/cuda.conf && \
+    ldconfig
+
+ENV PATH /usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
+ENV LD_LIBRARY_PATH /usr/local/nvidia/lib:/usr/local/nvidia/lib64:${LD_LIBRARY_PATH}
+
+ENV LIBRARY_PATH /usr/local/cuda/lib64/stubs:${LIBRARY_PATH}
+
+
+# https://raw.githubusercontent.com/NVIDIA/nvidia-docker/master/ubuntu-14.04/cuda/8.0/devel/cudnn5/Dockerfile
+# FROM cuda:8.0-devel
+
+# The hard part is knowing the path to the cudnn tar file.  
+ 
+###{{{ BEGIN excerpt from https://github.com/NVIDIA/nvidia-docker/blob/master/centos-7/cuda/7.5/devel/cudnn4/Dockerfile
+#
+ENV CUDNN_VERSION 4 
+LABEL com.nvidia.cudnn.version="4" 
+
+RUN CUDNN_DOWNLOAD_SUM=4e64ef7716f20c87854b4421863328e17cce633330c319b5e13809b61a36f97d && \ 
+    curl -fsSL http://developer.download.nvidia.com/compute/redist/cudnn/v4/cudnn-7.0-linux-x64-v4.0-prod.tgz -O && \ 
+    echo "$CUDNN_DOWNLOAD_SUM  cudnn-7.0-linux-x64-v4.0-prod.tgz" | sha256sum -c --strict - && \ 
+    tar -xzf cudnn-7.0-linux-x64-v4.0-prod.tgz -C /usr/local && \ 
+    rm cudnn-7.0-linux-x64-v4.0-prod.tgz && \ 
+    ldconfig 
+#
+###}}} END excerpt from https://github.com/NVIDIA/nvidia-docker/blob/master/centos-7/cuda/7.5/devel/cudnn4/Dockerfile
+
+# This is needed to suppress "libdc1394 error: Failed to initialize libdc1394" scary warning on AMI
+# See https://groups.google.com/forum/#!topic/digits-users/uvQpHooD6WY
+RUN ln /dev/null /dev/raw1394
+
+#
+#  End of NVidia Stuff 
+
+ENV TERM xterm
+
+RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
+  wget --quiet --no-check-certificate https://repo.continuum.io/archive/Anaconda2-2.4.1-Linux-x86_64.sh && \
+  /bin/bash Anaconda2-2.4.1-Linux-x86_64.sh -b -p /opt/conda && \
+  rm Anaconda2-2.4.1-Linux-x86_64.sh
+
+ENV PATH /opt/conda/bin:$PATH
+ENV PYTHONPATH /home/caffe-user/caffe/python:$PYTHONPATH
+
+RUN conda install -c https://conda.anaconda.org/memex elasticsearch-py && \
+  conda install -c https://conda.anaconda.org/anaconda protobuf
+  
+RUN pip install lmdb
+
+RUN useradd -ms /bin/bash caffe-user && echo "caffe-user:caffe-user" | chpasswd && adduser caffe-user sudo
+RUN chown -R caffe-user:caffe-user /usr/local
+
+# Clone Caffe repo and move into it
+RUN cd /home/caffe-user && git clone https://github.com/Russell91/nlpcaffe.git 
+
+# Clobber Makefile.config with GPU settings
+COPY Makefile.config /home/caffe-user/nlpcaffe
+# -j8 flag must be removed from make when running on Amazon GPU ... race condition occurs.
+RUN cd /home/caffe-user/nlpcaffe && make && make pycaffe && make distribute
+
+# There are some serious version sensitivities:  
+#    If these last 2 lines are above the "make" command
+#    then the build will fail
+RUN echo "/opt/conda/lib" >> /etc/ld.so.conf.d/protobuf.conf
+RUN ldconfig

--- a/docker/standalone/gpu/Ubuntu14.04-AMI/ubuntu-nvidia367.57-cuda7.5-cudnn4-gpu-nlpcaffe.docker
+++ b/docker/standalone/gpu/Ubuntu14.04-AMI/ubuntu-nvidia367.57-cuda7.5-cudnn4-gpu-nlpcaffe.docker
@@ -100,7 +100,7 @@ ENV LIBRARY_PATH /usr/local/cuda/lib64/stubs:${LIBRARY_PATH}
 ENV CUDNN_VERSION 4 
 LABEL com.nvidia.cudnn.version="4" 
 
-RUN CUDNN_DOWNLOAD_SUM=4e64ef7716f20c87854b4421863328e17cce633330c319b5e13809b61a36f97d && \ 
+RUN CUDNN_DOWNLOAD_SUM=cd091763d5889f0efff1fbda83bade191f530743a212c6b0ecc2a64d64d94405 && \ 
     curl -fsSL http://developer.download.nvidia.com/compute/redist/cudnn/v4/cudnn-7.0-linux-x64-v4.0-prod.tgz -O && \ 
     echo "$CUDNN_DOWNLOAD_SUM  cudnn-7.0-linux-x64-v4.0-prod.tgz" | sha256sum -c --strict - && \ 
     tar -xzf cudnn-7.0-linux-x64-v4.0-prod.tgz -C /usr/local && \ 

--- a/docker/standalone/gpu/Ubuntu14.04-AMI/ubuntu-nvidia367.57-cuda7.5-cudnn4-gpu-nlpcaffe.docker
+++ b/docker/standalone/gpu/Ubuntu14.04-AMI/ubuntu-nvidia367.57-cuda7.5-cudnn4-gpu-nlpcaffe.docker
@@ -77,7 +77,7 @@ LABEL com.nvidia.cuda.version="7.5"
 RUN curl -fsSL http://developer.download.nvidia.com/compute/cuda/7.5/Prod/local_installers/cuda_7.5.18_linux.run -O
 RUN chmod +x cuda_7.5.18_linux.run
 RUN ./cuda_7.5.18_linux.run --extract=$HOME
-RUN $HOME/cuda-linux64-rel-7.5.18-19867135.run -noprompt
+RUN $HOME/cuda-linux64-rel-7.5.18-19867135.run -noprompt --nox11
 RUN stat /usr/local/cuda/lib64
 
 RUN echo "/usr/local/cuda/lib" >> /etc/ld.so.conf.d/cuda.conf && \


### PR DESCRIPTION
I am committing scripts which start from a clean Ubuntu 14.04 image on an Amazon p2.xlarge GPU instance and successfully deploy nlpcaffe on Docker and use the GPU.